### PR TITLE
 Removed configuration and running of ecs-agent from recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,44 +23,9 @@ end
    end
 end
 
-template "/etc/ecs/ecs.config" do
-   source "ecs.config.erb"
-   mode "0644"
-   variables(
-      :data_dir => node['aws_ecs']['data_dir'],
-      :log_file => node['aws_ecs']['log_file'],
-      :cluster_name => node['aws_ecs']['cluster_name']
-   )
-   notifies :restart, "docker_container[ecs-agent]"
-end
-
 docker_image 'amazon/amazon-ecs-agent' do
   action :pull
   tag 'latest'
-  notifies :redeploy, 'docker_container[ecs-agent]'
-end
-
-docker_container 'ecs-agent' do
-  repo 'amazon/amazon-ecs-agent'
-  tag 'latest'
-  volumes [
-     '/var/run:/var/run',
-     '/var/log/ecs/:/log',
-     '/var/lib/ecs/data:/data',
-     '/etc/ecs:/etc/ecs']
-  restart_policy 'on-failure'
-  restart_maximum_retry_count 10
-  network_mode 'host'
-  env [
-     "ECS_DATADIR=#{node['aws_ecs']['data_dir']}",
-     'ECS_ENABLE_TASK_IAM_ROLE=true',
-     'ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true',
-     "ECS_LOGFILE=#{node['aws_ecs']['log_file']}",
-     'ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","awslogs"]',
-     'ECS_LOGLEVEL=info',
-     "ECS_CLUSTER=#{node['aws_ecs']['cluster_name']}"
-  ]
-  action :run
 end
 
 sysctl_param 'net.ipv4.conf.all.route_localnet' do

--- a/templates/default/ecs.config.erb
+++ b/templates/default/ecs.config.erb
@@ -1,7 +1,0 @@
-ECS_DATADIR=<%= @data_dir %>
-ECS_ENABLE_TASK_IAM_ROLE=true
-ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true
-ECS_LOGFILE=<%= @log_file %>
-ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","awslogs"]
-ECS_LOGLEVEL=info
-ECS_CLUSTER=<%= @cluster_name %>

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -12,14 +12,3 @@ describe 'ECS' do
   end
 end
 
-context 'Configuration' do
-   describe file '/etc/ecs/ecs.config' do
-      it { is_expected.to be_file }
-      describe '#content' do
-         subject { super().content }
-         it { is_expected.to contain('ECS_DATADIR=/datadir') }
-         it { is_expected.to contain('ECS_CLUSTER=test') }
-         it { is_expected.to contain('ECS_LOGFILE=/log/ecs-agent.log')}
-      end
-   end
-end


### PR DESCRIPTION
Removed running of the ecs-agent and creation of a useless config file.
Userdata will control the startup of the agent when ready.

also removed a now pointless test.